### PR TITLE
Fix white screen on editable element click

### DIFF
--- a/src/editor/components/PreviewCanvas.tsx
+++ b/src/editor/components/PreviewCanvas.tsx
@@ -259,7 +259,8 @@ export default function PreviewCanvas() {
     if (editableElement) {
       console.log('PreviewCanvas: Found editable element:', editableElement);
       // Set the selected element in the store for the properties panel
-      setSelectedElement(editableElement);
+      // Store the actual DOM element, which the PropertiesPanel/ElementEditor expects
+      setSelectedElement(editableElement.element);
       // Clear section/block selection since we're now editing individual elements
       setSelectedSection(null);
       setSelectedBlock(null);

--- a/src/editor/services/ElementDiscoveryService.ts
+++ b/src/editor/services/ElementDiscoveryService.ts
@@ -97,6 +97,15 @@ export class ElementDiscoveryService {
       ...this.getElementSpecificData(element, tagName)
     };
 
+    // Attach lightweight editor metadata to the DOM element for downstream editors
+    try {
+      (element as any)._editorData = {
+        id,
+        type,
+        pageId: this.pageId
+      };
+    } catch {}
+
     return editableElement;
   }
 


### PR DESCRIPTION
Fix white screen when clicking an element in the editor by passing the raw DOM element instead of the wrapped object, and attach necessary editor metadata directly to the element.

---
<a href="https://cursor.com/background-agent?bcId=bc-588e328d-2ab0-453d-9cfd-216f3d39083e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-588e328d-2ab0-453d-9cfd-216f3d39083e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

