### PR TITLE
Fix editor editing bug after responsive preview changes

### DIFF
--- a/src/editor/services/ElementDiscoveryService.ts
+++ b/src/editor/services/ElementDiscoveryService.ts
@@ -177,6 +177,15 @@ export class ElementDiscoveryService {
   }
 
   private isEditorElement(element: HTMLElement): boolean {
+    // Never treat elements inside the preview canvas as editor UI
+    // The preview root uses classes like 'editor-responsive-mode' which contain the word 'editor'
+    // and could otherwise be mistakenly matched by the broad selectors below.
+    try {
+      if (element.closest('.live-website-renderer')) {
+        return false;
+      }
+    } catch {}
+
     // Check if element is part of the editor UI
     const editorSelectors = [
       '[data-editor]',


### PR DESCRIPTION
Fixes editor uneditable state by preventing elements within the preview from being misidentified as editor UI.

The responsive preview work added the `editor-responsive-mode` class to the preview container. The `isEditorElement` filter was too broad, causing all elements inside the preview to be treated as editor UI and filtered out, making them uneditable. This PR adds a safeguard to `isEditorElement` to ignore elements under `.live-website-renderer`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fabcb2e-a09a-4485-a76c-2ad7db867885">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fabcb2e-a09a-4485-a76c-2ad7db867885">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

